### PR TITLE
Updating to match Impala source

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -39,7 +39,10 @@ func Connect(host, port string, options Options) (*Connection, error) {
 	transportFactory := thrift.NewTBufferedTransportFactory(1024)
 	protocolFactory := thrift.NewTBinaryProtocolFactoryDefault()
 
-	transport := transportFactory.GetTransport(socket)
+	transport, err := transportFactory.GetTransport(socket)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := transport.Open(); err != nil {
 		return nil, err


### PR DESCRIPTION
Apache changed `transportFactory.GetTransport() to return an error value in addition to the transport.